### PR TITLE
Fix README, and add a test fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@ model = AttentionBasedInflationBlock(dim=512, heads=4, dropout=0.1)
 out = model(x)
 
 # print
-print(out.shape)  # Expected shape: [1, 4, 224, 224, 3]
+print(out.shape)  # Expected shape: [1, 4, 224, 224, 512]
+
+```
+
+## Test
+```
+poetry run pytest
+
+# or
+pytest tests/
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ zetascale = "*"
 einops = "*"
 torch = "*"
 
-
+[tool.pytest.ini_options]
+pythonpath = "tests"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "^0.1.6"

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,0 +1,16 @@
+import torch
+from lumiere.model import AttentionBasedInflationBlock
+
+import pytest
+
+@pytest.fixture
+def lumiere_fixture():
+    # B, T, H, W, D
+    x = torch.randn(1, 4, 224, 224, 512)
+    # Model
+    model = AttentionBasedInflationBlock(dim=512, heads=4, dropout=0.1)
+    # Forward pass
+    return model(x)
+
+def test_with_fixture(lumiere_fixture):
+    assert list(lumiere_fixture.shape) == [1, 4, 224, 224, 512]


### PR DESCRIPTION
Noticed zeta/nn/qformer had merge artifacts in what was installed from pip, when reviewing this for the first time, 
             So I guess the problem is not with this package, however I corrected the README and added a test for good measure
Issue: https://github.com/kyegomez/zeta/issues/138
Dependencies: pytest
Twitter handle: zenstyle